### PR TITLE
#9 Cadastro e edição de tipo de problema

### DIFF
--- a/src/components/DashboardOptions.tsx
+++ b/src/components/DashboardOptions.tsx
@@ -1,37 +1,42 @@
 import { ReactNode } from 'react';
+import NextLink from 'next/link';
 import { Box, Button, Text } from '@chakra-ui/react';
 
 interface DashboardOptionsProps {
   title: string;
   isActive?: boolean;
   icon?: ReactNode;
+  goTo?: string;
 }
 
 export const DashboardOptions = ({
   title,
   icon,
   isActive,
+  goTo,
 }: DashboardOptionsProps) => {
   return (
-    <Button
-      bg={isActive ? 'primary' : 'white'}
-      color={isActive ? 'white' : 'black'}
-      size='sm'
-      w='235px'
-      h='48px'
-      // eslint-disable-next-line react-perf/jsx-no-new-object-as-prop -- its necessary since _hover NEEDS a css style object
-      _hover={{ bg: 'primary', color: 'white' }}
-    >
-      <Box
-        w='100%'
-        display='flex'
-        alignItems='center'
-        gap='12px'
-        fontSize='medium'
+    <NextLink href={'/' + goTo} passHref>
+      <Button
+        bg={isActive ? 'primary' : 'white'}
+        color={isActive ? 'white' : 'black'}
+        size='sm'
+        w='235px'
+        h='48px'
+        // eslint-disable-next-line react-perf/jsx-no-new-object-as-prop -- its necessary since _hover NEEDS a css style object
+        _hover={{ bg: 'primary', color: 'white' }}
       >
-        <Box fontSize='xx-large'>{icon}</Box>
-        <Text lineHeight='initial'>{title}</Text>
-      </Box>
-    </Button>
+        <Box
+          w='100%'
+          display='flex'
+          alignItems='center'
+          gap='12px'
+          fontSize='medium'
+        >
+          <Box fontSize='xx-large'>{icon}</Box>
+          <Text lineHeight='initial'>{title}</Text>
+        </Box>
+      </Button>
+    </NextLink>
   );
 };

--- a/src/components/DataType.ts
+++ b/src/components/DataType.ts
@@ -1,0 +1,7 @@
+export type Data1 = {
+  id: number;
+  name: string;
+  description: string;
+  active: boolean;
+  updatedAt: Date;
+};

--- a/src/components/DataType.ts
+++ b/src/components/DataType.ts
@@ -1,7 +1,16 @@
-export type Data1 = {
+export type DataCategory = {
   id: number;
   name: string;
   description: string;
   active: boolean;
-  updatedAt: Date;
+  updated_at: Date;
+};
+
+export type DataProbType = {
+  id: number;
+  name: string;
+  description: string;
+  active: boolean;
+  updated_at: Date;
+  category_id: number;
 };

--- a/src/components/ItemCategory.tsx
+++ b/src/components/ItemCategory.tsx
@@ -1,7 +1,12 @@
-import Link from 'next/link';
 import { VscAdd } from 'react-icons/vsc';
-import { Box, Flex, Text } from '@chakra-ui/react';
+import {
+  Box,
+  Flex,
+  Text,
+  useDisclosure,
+} from '@chakra-ui/react';
 
+import { ModalCadType } from './ModalCadType';
 import { ModalDelCategory } from './ModalDelCategory';
 import { ModalEditCategory } from './ModalEditCategory';
 
@@ -28,6 +33,8 @@ export const ItemCategory = ({
   callBackEdit,
   callBackDel,
 }: CategoriesItemProps) => {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+
   return (
     <Box key={id} mt='2em'>
       <Flex w='100%'>
@@ -44,11 +51,15 @@ export const ItemCategory = ({
           fontSize={'xl'}
           // eslint-disable-next-line react-perf/jsx-no-new-object-as-prop -- its necessary since _hover NEEDS a css style object
           _hover={{ boxShadow: 'dark-lg' }}
+          onClick={onOpen}
         >
-          <Link href={'/teste'}>
-            <VscAdd color='#405866' />
-          </Link>
+          <VscAdd color='#405866' />
         </Box>
+        <ModalCadType
+          isOpen={isOpen}
+          onClose={onClose}
+          categoryId={2}
+        />
         <ModalEditCategory
           id={id}
           name={name}

--- a/src/components/ItemCategory.tsx
+++ b/src/components/ItemCategory.tsx
@@ -1,9 +1,4 @@
-import {
-  Box,
-  Flex,
-  Text,
-  useDisclosure,
-} from '@chakra-ui/react';
+import { Box, Flex, Text } from '@chakra-ui/react';
 
 import { ModalCadType } from './ModalCadType';
 import { ModalDelCategory } from './ModalDelCategory';
@@ -32,8 +27,6 @@ export const ItemCategory = ({
   callBackEdit,
   callBackDel,
 }: CategoriesItemProps) => {
-  const { isOpen, onOpen, onClose } = useDisclosure();
-
   return (
     <Box key={id} mt='2em'>
       <Flex w='100%'>

--- a/src/components/ItemCategory.tsx
+++ b/src/components/ItemCategory.tsx
@@ -1,4 +1,10 @@
-import { Box, Flex, Text } from '@chakra-ui/react';
+import { VscAdd } from 'react-icons/vsc';
+import {
+  Box,
+  Flex,
+  Text,
+  useDisclosure,
+} from '@chakra-ui/react';
 
 import { ModalCadType } from './ModalCadType';
 import { ModalDelCategory } from './ModalDelCategory';
@@ -27,6 +33,8 @@ export const ItemCategory = ({
   callBackEdit,
   callBackDel,
 }: CategoriesItemProps) => {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+
   return (
     <Box key={id} mt='2em'>
       <Flex w='100%'>
@@ -36,7 +44,22 @@ export const ItemCategory = ({
             {description}
           </Text>
         </Box>
-        <ModalCadType categoryId={2} />
+        <Box
+          m='0 auto'
+          mt='1em'
+          maxH={'20px'}
+          fontSize={'xl'}
+          // eslint-disable-next-line react-perf/jsx-no-new-object-as-prop -- its necessary since _hover NEEDS a css style object
+          _hover={{ boxShadow: 'dark-lg' }}
+          onClick={onOpen}
+        >
+          <VscAdd color='#405866' />
+        </Box>
+        <ModalCadType
+          onClose={onClose}
+          isOpen={isOpen}
+          categoryId={2}
+        />
         <ModalEditCategory
           id={id}
           name={name}

--- a/src/components/ItemCategory.tsx
+++ b/src/components/ItemCategory.tsx
@@ -1,4 +1,3 @@
-import { VscAdd } from 'react-icons/vsc';
 import {
   Box,
   Flex,
@@ -44,22 +43,7 @@ export const ItemCategory = ({
             {description}
           </Text>
         </Box>
-        <Box
-          m='0 auto'
-          mt='1em'
-          maxH={'20px'}
-          fontSize={'xl'}
-          // eslint-disable-next-line react-perf/jsx-no-new-object-as-prop -- its necessary since _hover NEEDS a css style object
-          _hover={{ boxShadow: 'dark-lg' }}
-          onClick={onOpen}
-        >
-          <VscAdd color='#405866' />
-        </Box>
-        <ModalCadType
-          isOpen={isOpen}
-          onClose={onClose}
-          categoryId={2}
-        />
+        <ModalCadType categoryId={2} />
         <ModalEditCategory
           id={id}
           name={name}

--- a/src/components/ModalCadCategory.tsx
+++ b/src/components/ModalCadCategory.tsx
@@ -18,10 +18,10 @@ import {
 
 import { listcategory } from '@services/testApi';
 
-import { Data1 } from './DataType';
+import { DataCategory } from './DataType';
 
 interface ModalCadCategoryProps {
-  callBack: (novaCategoria: Data1) => void;
+  callBack: (novaCategoria: DataCategory) => void;
 }
 
 export const ModalCadCategory = ({
@@ -34,9 +34,11 @@ export const ModalCadCategory = ({
     register,
     reset,
     formState: {},
-  } = useForm<Data1>();
+  } = useForm<DataCategory>();
 
-  const onSubmit: SubmitHandler<Data1> = async (data) => {
+  const onSubmit: SubmitHandler<DataCategory> = async (
+    data
+  ) => {
     listcategory
       .post('/users', data)
       .then(() => {
@@ -86,7 +88,10 @@ export const ModalCadCategory = ({
           onClose={onClose}
           size={'xl'}
         >
-          <ModalOverlay />
+          <ModalOverlay
+            backdropFilter={'auto'}
+            backdropBlur={'2px'}
+          />
           <ModalContent>
             <ModalHeader
               textAlign={'center'}

--- a/src/components/ModalCadCategory.tsx
+++ b/src/components/ModalCadCategory.tsx
@@ -18,13 +18,7 @@ import {
 
 import { listcategory } from '@services/testApi';
 
-interface Data1 {
-  id: number;
-  name: string;
-  description: string;
-  active: boolean;
-  updatedAt: Date;
-}
+import { Data1 } from './DataType';
 
 interface ModalCadCategoryProps {
   callBack: (novaCategoria: Data1) => void;

--- a/src/components/ModalCadType.tsx
+++ b/src/components/ModalCadType.tsx
@@ -1,4 +1,5 @@
 import { SubmitHandler, useForm } from 'react-hook-form';
+import { VscAdd } from 'react-icons/vsc';
 import { toast } from 'react-toastify';
 import {
   Box,
@@ -13,6 +14,7 @@ import {
   ModalHeader,
   ModalOverlay,
   Text,
+  useDisclosure,
 } from '@chakra-ui/react';
 
 import { typeApi } from '@services/testApi';
@@ -21,16 +23,13 @@ import { DataProbType } from './DataType';
 
 interface ModalCadTypeProps {
   // callBack: (novoTipo: DataProbType) => void;
-  onClose: () => void;
-  isOpen: boolean;
   categoryId: number;
 }
 
 export const ModalCadType = ({
-  onClose,
-  isOpen,
   categoryId,
 }: ModalCadTypeProps) => {
+  const { isOpen, onOpen, onClose } = useDisclosure();
   const {
     handleSubmit,
     register,
@@ -69,6 +68,17 @@ export const ModalCadType = ({
 
   return (
     <>
+      <Box
+        m='0 auto'
+        mt='1em'
+        maxH={'20px'}
+        fontSize={'xl'}
+        // eslint-disable-next-line react-perf/jsx-no-new-object-as-prop -- its necessary since _hover NEEDS a css style object
+        _hover={{ boxShadow: 'dark-lg' }}
+        onClick={onOpen}
+      >
+        <VscAdd color='#405866' />
+      </Box>
       <Box fontFamily={'Overpass ,sans-serif'}>
         <Modal
           isOpen={isOpen}

--- a/src/components/ModalCadType.tsx
+++ b/src/components/ModalCadType.tsx
@@ -15,36 +15,42 @@ import {
   Text,
 } from '@chakra-ui/react';
 
-import { listcategory } from '@services/testApi';
+import { typeApi } from '@services/testApi';
 
-import { Data1 } from './DataType';
+import { DataProbType } from './DataType';
 
 interface ModalCadTypeProps {
-  callBack: (novaCategoria: Data1) => void;
-  onOpen: () => void;
+  callBack: (novoTipo: DataProbType) => void;
   onClose: () => void;
   isOpen: boolean;
+  categoryId: number;
 }
 
 export const ModalCadType = ({
   callBack,
-  onOpen,
   onClose,
   isOpen,
+  categoryId,
 }: ModalCadTypeProps) => {
   const {
     handleSubmit,
     register,
     reset,
     formState: {},
-  } = useForm<Data1>();
+  } = useForm<DataProbType>();
 
-  const onSubmit: SubmitHandler<Data1> = async (data) => {
-    listcategory
+  const onSubmit: SubmitHandler<DataProbType> = async (
+    data
+  ) => {
+    data.category_id = categoryId;
+    data.active = true;
+    typeApi
       .post('/users', data)
       .then(() => {
         toast.success(
-          'A categoria ' + data.name + ' foi cadastrada',
+          'O tipo ' +
+            data.name +
+            ' foi cadastrado com sucesso',
           {
             position: 'top-left',
             autoClose: 2000,
@@ -54,7 +60,7 @@ export const ModalCadType = ({
         reset();
       })
       .catch(() => {
-        toast.warning('Falha ao criar categoria', {
+        toast.warning('Falha ao criar tipo de problema', {
           position: 'top-left',
           autoClose: 2000,
         });
@@ -76,7 +82,7 @@ export const ModalCadType = ({
               fontSize={'3xl'}
               fontFamily={'Overpass ,sans-serif'}
             >
-              Nova Categoria de Problema
+              Novo Tipo de Problema
             </ModalHeader>
 
             <ModalBody fontFamily={'Overpass ,sans-serif'}>
@@ -129,7 +135,7 @@ export const ModalCadType = ({
                     boxShadow={'dark-lg'}
                   >
                     <Text fontSize={'smaller'}>
-                      REGISTRAR CATEGORIA DE<p></p> PROBLEMA
+                      REGISTRAR TIPO DE<p></p> PROBLEMA
                     </Text>
                   </Button>
                 </ModalFooter>

--- a/src/components/ModalCadType.tsx
+++ b/src/components/ModalCadType.tsx
@@ -75,7 +75,10 @@ export const ModalCadType = ({
           onClose={onClose}
           size={'xl'}
         >
-          <ModalOverlay />
+          <ModalOverlay
+            backdropFilter={'auto'}
+            backdropBlur={'2px'}
+          />
           <ModalContent>
             <ModalHeader
               textAlign={'center'}

--- a/src/components/ModalCadType.tsx
+++ b/src/components/ModalCadType.tsx
@@ -1,0 +1,143 @@
+import { SubmitHandler, useForm } from 'react-hook-form';
+import { toast } from 'react-toastify';
+import {
+  Box,
+  Button,
+  FormControl,
+  FormLabel,
+  Input,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Text,
+} from '@chakra-ui/react';
+
+import { listcategory } from '@services/testApi';
+
+import { Data1 } from './DataType';
+
+interface ModalCadTypeProps {
+  callBack: (novaCategoria: Data1) => void;
+  onOpen: () => void;
+  onClose: () => void;
+  isOpen: boolean;
+}
+
+export const ModalCadType = ({
+  callBack,
+  onOpen,
+  onClose,
+  isOpen,
+}: ModalCadTypeProps) => {
+  const {
+    handleSubmit,
+    register,
+    reset,
+    formState: {},
+  } = useForm<Data1>();
+
+  const onSubmit: SubmitHandler<Data1> = async (data) => {
+    listcategory
+      .post('/users', data)
+      .then(() => {
+        toast.success(
+          'A categoria ' + data.name + ' foi cadastrada',
+          {
+            position: 'top-left',
+            autoClose: 2000,
+          }
+        );
+        callBack(data);
+        reset();
+      })
+      .catch(() => {
+        toast.warning('Falha ao criar categoria', {
+          position: 'top-left',
+          autoClose: 2000,
+        });
+      });
+  };
+
+  return (
+    <>
+      <Box fontFamily={'Overpass ,sans-serif'}>
+        <Modal
+          isOpen={isOpen}
+          onClose={onClose}
+          size={'xl'}
+        >
+          <ModalOverlay />
+          <ModalContent>
+            <ModalHeader
+              textAlign={'center'}
+              fontSize={'3xl'}
+              fontFamily={'Overpass ,sans-serif'}
+            >
+              Nova Categoria de Problema
+            </ModalHeader>
+
+            <ModalBody fontFamily={'Overpass ,sans-serif'}>
+              <form onSubmit={handleSubmit(onSubmit)}>
+                <Box w={'50%'} m={'0 auto'}>
+                  <FormControl isRequired>
+                    <FormLabel>Nome</FormLabel>
+                    <Input
+                      borderRadius={'8px'}
+                      size={'sm'}
+                      placeholder='Nome'
+                      {...register('name')}
+                    />
+                  </FormControl>
+
+                  <FormControl mt={'24px'}>
+                    <FormLabel>Descrição</FormLabel>
+                    <Input
+                      borderRadius={'8px'}
+                      size={'sm'}
+                      placeholder='Descrição'
+                      {...register('description')}
+                    />
+                  </FormControl>
+                </Box>
+
+                <ModalFooter
+                  justifyContent={'center'}
+                  mt={'60px'}
+                >
+                  <Button
+                    variant={'solid'}
+                    bg='InfoBackground'
+                    color='black'
+                    mr={'30px'}
+                    onClick={onClose}
+                    border={'1px'}
+                    borderColor={'black'}
+                    borderRadius={'50px'}
+                    fontSize={'medium'}
+                  >
+                    Cancelar
+                  </Button>
+                  <Button
+                    colorScheme={'orange'}
+                    bg='primary'
+                    color={'white'}
+                    type='submit'
+                    borderRadius={'50px'}
+                    boxShadow={'dark-lg'}
+                  >
+                    <Text fontSize={'smaller'}>
+                      REGISTRAR CATEGORIA DE<p></p> PROBLEMA
+                    </Text>
+                  </Button>
+                </ModalFooter>
+              </form>
+            </ModalBody>
+          </ModalContent>
+        </Modal>
+      </Box>
+    </>
+  );
+};

--- a/src/components/ModalCadType.tsx
+++ b/src/components/ModalCadType.tsx
@@ -1,5 +1,4 @@
 import { SubmitHandler, useForm } from 'react-hook-form';
-import { VscAdd } from 'react-icons/vsc';
 import { toast } from 'react-toastify';
 import {
   Box,
@@ -14,7 +13,6 @@ import {
   ModalHeader,
   ModalOverlay,
   Text,
-  useDisclosure,
 } from '@chakra-ui/react';
 
 import { typeApi } from '@services/testApi';
@@ -22,14 +20,18 @@ import { typeApi } from '@services/testApi';
 import { DataProbType } from './DataType';
 
 interface ModalCadTypeProps {
-  // callBack: (novoTipo: DataProbType) => void;
+  callBack?: (novoTipo: DataProbType) => void;
   categoryId: number;
+  isOpen: boolean;
+  onClose: () => void;
 }
 
 export const ModalCadType = ({
   categoryId,
+  callBack,
+  onClose,
+  isOpen,
 }: ModalCadTypeProps) => {
-  const { isOpen, onOpen, onClose } = useDisclosure();
   const {
     handleSubmit,
     register,
@@ -54,7 +56,11 @@ export const ModalCadType = ({
             autoClose: 2000,
           }
         );
-        // callBack(data);
+
+        if (callBack !== undefined) {
+          callBack(data);
+        }
+
         reset();
       })
       .catch((error) => {
@@ -68,17 +74,6 @@ export const ModalCadType = ({
 
   return (
     <>
-      <Box
-        m='0 auto'
-        mt='1em'
-        maxH={'20px'}
-        fontSize={'xl'}
-        // eslint-disable-next-line react-perf/jsx-no-new-object-as-prop -- its necessary since _hover NEEDS a css style object
-        _hover={{ boxShadow: 'dark-lg' }}
-        onClick={onOpen}
-      >
-        <VscAdd color='#405866' />
-      </Box>
       <Box fontFamily={'Overpass ,sans-serif'}>
         <Modal
           isOpen={isOpen}

--- a/src/components/ModalDelCategory.tsx
+++ b/src/components/ModalDelCategory.tsx
@@ -73,63 +73,65 @@ export const ModalDelCategory = ({
           isOpen={isOpen}
           onClose={onClose}
         >
-          <ModalOverlay>
-            <ModalContent>
-              <ModalHeader
-                fontSize='3xl'
-                fontWeight='bold'
+          <ModalOverlay
+            backdropFilter={'auto'}
+            backdropBlur={'2px'}
+          />
+          <ModalContent>
+            <ModalHeader
+              fontSize='3xl'
+              fontWeight='bold'
+              m={'0 auto'}
+              fontFamily={'Overpass ,sans-serif'}
+            >
+              Remover Categoria de Problema
+            </ModalHeader>
+
+            <ModalBody>
+              <Text
+                w='60%'
                 m={'0 auto'}
+                textAlign={'justify'}
+                fontSize={'md'}
                 fontFamily={'Overpass ,sans-serif'}
               >
-                Remover Categoria de Problema
-              </ModalHeader>
+                Você está prestes a remover a categoria
+                {' ' + name + ' '} e todos os tipos de
+                problemas relacionados a ela. Tem certeza
+                disso?
+              </Text>
+            </ModalBody>
 
-              <ModalBody>
-                <Text
-                  w='60%'
-                  m={'0 auto'}
-                  textAlign={'justify'}
-                  fontSize={'md'}
-                  fontFamily={'Overpass ,sans-serif'}
-                >
-                  Você está prestes a remover a categoria
-                  {' ' + name + ' '} e todos os tipos de
-                  problemas relacionados a ela. Tem certeza
-                  disso?
-                </Text>
-              </ModalBody>
-
-              <ModalFooter
-                fontFamily={'Overpass ,sans-serif'}
-                justifyContent={'center'}
-                mt={'30px'}
+            <ModalFooter
+              fontFamily={'Overpass ,sans-serif'}
+              justifyContent={'center'}
+              mt={'30px'}
+            >
+              <Button
+                colorScheme='green'
+                bg={'#22A122'}
+                onClick={onClose}
+                fontSize={'md'}
+                borderRadius={'50px'}
+                maxH={'35px'}
+                w={'190px'}
               >
-                <Button
-                  colorScheme='green'
-                  bg={'#22A122'}
-                  onClick={onClose}
-                  fontSize={'md'}
-                  borderRadius={'50px'}
-                  maxH={'35px'}
-                  w={'190px'}
-                >
-                  CANCELAR
-                </Button>
-                <Button
-                  colorScheme='red'
-                  bg={'#DE4040'}
-                  onClick={DeleteCategory}
-                  ml={5}
-                  fontSize={'18px'}
-                  borderRadius={'50px'}
-                  maxH={'35px'}
-                  w={'250px'}
-                >
-                  SIM, TENHO CERTEZA
-                </Button>
-              </ModalFooter>
-            </ModalContent>
-          </ModalOverlay>
+                CANCELAR
+              </Button>
+              <Button
+                colorScheme='red'
+                bg={'#DE4040'}
+                onClick={DeleteCategory}
+                ml={5}
+                fontSize={'18px'}
+                borderRadius={'50px'}
+                maxH={'35px'}
+                w={'250px'}
+              >
+                SIM, TENHO CERTEZA
+              </Button>
+            </ModalFooter>
+          </ModalContent>
         </Modal>
       </Box>
     </>

--- a/src/components/ModalDelType.tsx
+++ b/src/components/ModalDelType.tsx
@@ -75,62 +75,64 @@ export const ModalDelType = ({
           isOpen={isOpen}
           onClose={onClose}
         >
-          <ModalOverlay>
-            <ModalContent>
-              <ModalHeader
-                fontSize='3xl'
-                fontWeight='bold'
+          <ModalOverlay
+            backdropFilter={'auto'}
+            backdropBlur={'2px'}
+          />
+          <ModalContent>
+            <ModalHeader
+              fontSize='3xl'
+              fontWeight='bold'
+              m={'0 auto'}
+              fontFamily={'Overpass ,sans-serif'}
+            >
+              Remover Tipo de Problema
+            </ModalHeader>
+
+            <ModalBody>
+              <Text
+                w='60%'
                 m={'0 auto'}
+                textAlign={'justify'}
+                fontSize={'md'}
                 fontFamily={'Overpass ,sans-serif'}
               >
-                Remover Tipo de Problema
-              </ModalHeader>
+                Você está prestes a remover o tipo de
+                problema
+                {' ' + name + ' '}. Tem certeza disso?
+              </Text>
+            </ModalBody>
 
-              <ModalBody>
-                <Text
-                  w='60%'
-                  m={'0 auto'}
-                  textAlign={'justify'}
-                  fontSize={'md'}
-                  fontFamily={'Overpass ,sans-serif'}
-                >
-                  Você está prestes a remover o tipo de
-                  problema
-                  {' ' + name + ' '}. Tem certeza disso?
-                </Text>
-              </ModalBody>
-
-              <ModalFooter
-                fontFamily={'Overpass ,sans-serif'}
-                justifyContent={'center'}
-                mt={'30px'}
+            <ModalFooter
+              fontFamily={'Overpass ,sans-serif'}
+              justifyContent={'center'}
+              mt={'30px'}
+            >
+              <Button
+                colorScheme='green'
+                bg={'#22A122'}
+                onClick={onClose}
+                fontSize={'md'}
+                borderRadius={'50px'}
+                maxH={'35px'}
+                w={'190px'}
               >
-                <Button
-                  colorScheme='green'
-                  bg={'#22A122'}
-                  onClick={onClose}
-                  fontSize={'md'}
-                  borderRadius={'50px'}
-                  maxH={'35px'}
-                  w={'190px'}
-                >
-                  CANCELAR
-                </Button>
-                <Button
-                  colorScheme='red'
-                  bg={'#DE4040'}
-                  onClick={DeleteType}
-                  ml={5}
-                  fontSize={'18px'}
-                  borderRadius={'50px'}
-                  maxH={'35px'}
-                  w={'250px'}
-                >
-                  SIM, TENHO CERTEZA
-                </Button>
-              </ModalFooter>
-            </ModalContent>
-          </ModalOverlay>
+                CANCELAR
+              </Button>
+              <Button
+                colorScheme='red'
+                bg={'#DE4040'}
+                onClick={DeleteType}
+                ml={5}
+                fontSize={'18px'}
+                borderRadius={'50px'}
+                maxH={'35px'}
+                w={'250px'}
+              >
+                SIM, TENHO CERTEZA
+              </Button>
+            </ModalFooter>
+          </ModalContent>
         </Modal>
       </Box>
     </>

--- a/src/components/ModalEditCategory.tsx
+++ b/src/components/ModalEditCategory.tsx
@@ -84,6 +84,7 @@ export const ModalEditCategory = ({
         m='0 auto'
         mt='1em'
         maxH={'20px'}
+        maxW={'20px'}
         fontSize={'xl'}
         // eslint-disable-next-line react-perf/jsx-no-new-object-as-prop -- Its hover.
         _hover={{ boxShadow: 'dark-lg' }}

--- a/src/components/ModalEditCategory.tsx
+++ b/src/components/ModalEditCategory.tsx
@@ -92,7 +92,10 @@ export const ModalEditCategory = ({
         <BiEditAlt />
       </Box>
       <Modal isOpen={isOpen} onClose={onClose} size={'xl'}>
-        <ModalOverlay />
+        <ModalOverlay
+          backdropFilter={'auto'}
+          backdropBlur={'2px'}
+        />
         <ModalContent>
           <ModalHeader
             textAlign={'center'}

--- a/src/components/ModalEditType.tsx
+++ b/src/components/ModalEditType.tsx
@@ -20,16 +20,17 @@ import { typeApi } from '@services/testApi';
 import { DataProbType } from './DataType';
 
 interface ModalCadTypeProps {
-  // callBack: (novoTipo: DataProbType) => void;
+  callBack: (novoTipo: DataProbType) => void;
   onClose: () => void;
   isOpen: boolean;
   categoryId: number;
 }
 
-export const ModalCadType = ({
+export const ModalEditType = ({
   onClose,
   isOpen,
   categoryId,
+  callBack,
 }: ModalCadTypeProps) => {
   const {
     handleSubmit,
@@ -44,7 +45,7 @@ export const ModalCadType = ({
     data.category_id = categoryId;
     data.active = true;
     typeApi
-      .post('/users', data)
+      .put('/users', data)
       .then(() => {
         toast.success(
           'O tipo ' +
@@ -55,7 +56,7 @@ export const ModalCadType = ({
             autoClose: 2000,
           }
         );
-        // callBack(data);
+        callBack(data);
         reset();
       })
       .catch((error) => {

--- a/src/components/ModalEditType.tsx
+++ b/src/components/ModalEditType.tsx
@@ -60,8 +60,9 @@ export const ModalEditType = ({
         );
         callBack(data);
         reset();
+        onClose();
       })
-      .catch((error) => {
+      .catch(() => {
         toast.warning(
           'Falha ao atualizar tipo de problema',
           {
@@ -69,7 +70,6 @@ export const ModalEditType = ({
             autoClose: 2000,
           }
         );
-        console.log(error);
       });
   };
 

--- a/src/components/ModalEditType.tsx
+++ b/src/components/ModalEditType.tsx
@@ -1,4 +1,5 @@
 import { SubmitHandler, useForm } from 'react-hook-form';
+import { BiEditAlt } from 'react-icons/bi';
 import { toast } from 'react-toastify';
 import {
   Box,
@@ -13,6 +14,7 @@ import {
   ModalHeader,
   ModalOverlay,
   Text,
+  useDisclosure,
 } from '@chakra-ui/react';
 
 import { typeApi } from '@services/testApi';
@@ -21,19 +23,16 @@ import { DataProbType } from './DataType';
 
 interface ModalCadTypeProps {
   callBack: (novoTipo: DataProbType) => void;
-  onClose: () => void;
-  isOpen: boolean;
   categoryId: number;
   id: number;
 }
 
 export const ModalEditType = ({
-  onClose,
-  isOpen,
   categoryId,
   id,
   callBack,
 }: ModalCadTypeProps) => {
+  const { isOpen, onOpen, onClose } = useDisclosure();
   const {
     handleSubmit,
     register,
@@ -77,6 +76,18 @@ export const ModalEditType = ({
   return (
     <>
       <Box fontFamily={'Overpass ,sans-serif'}>
+        <Box
+          m='0 auto'
+          mt='1em'
+          maxH={'20px'}
+          maxW={'20px'}
+          fontSize={'xl'}
+          // eslint-disable-next-line react-perf/jsx-no-new-object-as-prop -- Its hover.
+          _hover={{ boxShadow: 'dark-lg' }}
+          onClick={onOpen}
+        >
+          <BiEditAlt />
+        </Box>
         <Modal
           isOpen={isOpen}
           onClose={onClose}

--- a/src/components/ModalEditType.tsx
+++ b/src/components/ModalEditType.tsx
@@ -24,12 +24,14 @@ interface ModalCadTypeProps {
   onClose: () => void;
   isOpen: boolean;
   categoryId: number;
+  id: number;
 }
 
 export const ModalEditType = ({
   onClose,
   isOpen,
   categoryId,
+  id,
   callBack,
 }: ModalCadTypeProps) => {
   const {
@@ -39,18 +41,19 @@ export const ModalEditType = ({
     formState: {},
   } = useForm<DataProbType>();
 
-  const onSubmit: SubmitHandler<DataProbType> = async (
+  const onEdit: SubmitHandler<DataProbType> = async (
     data
   ) => {
+    data.id = id;
     data.category_id = categoryId;
     data.active = true;
     typeApi
-      .put('/users', data)
+      .put('/users/' + data.id, data)
       .then(() => {
         toast.success(
           'O tipo ' +
             data.name +
-            ' foi cadastrado com sucesso',
+            ' foi atualizado com sucesso',
           {
             position: 'top-left',
             autoClose: 2000,
@@ -60,10 +63,13 @@ export const ModalEditType = ({
         reset();
       })
       .catch((error) => {
-        toast.warning('Falha ao criar tipo de problema', {
-          position: 'top-left',
-          autoClose: 2000,
-        });
+        toast.warning(
+          'Falha ao atualizar tipo de problema',
+          {
+            position: 'top-left',
+            autoClose: 2000,
+          }
+        );
         console.log(error);
       });
   };
@@ -76,18 +82,21 @@ export const ModalEditType = ({
           onClose={onClose}
           size={'xl'}
         >
-          <ModalOverlay />
+          <ModalOverlay
+            backdropFilter={'auto'}
+            backdropBlur={'2px'}
+          />
           <ModalContent>
             <ModalHeader
               textAlign={'center'}
               fontSize={'3xl'}
               fontFamily={'Overpass ,sans-serif'}
             >
-              Novo Tipo de Problema
+              Editar Tipo de Problema
             </ModalHeader>
 
             <ModalBody fontFamily={'Overpass ,sans-serif'}>
-              <form onSubmit={handleSubmit(onSubmit)}>
+              <form onSubmit={handleSubmit(onEdit)}>
                 <Box w={'50%'} m={'0 auto'}>
                   <FormControl isRequired>
                     <FormLabel>Nome</FormLabel>
@@ -136,7 +145,7 @@ export const ModalEditType = ({
                     boxShadow={'dark-lg'}
                   >
                     <Text fontSize={'smaller'}>
-                      REGISTRAR TIPO DE<p></p> PROBLEMA
+                      ATUALIZAR TIPO DE<p></p> PROBLEMA
                     </Text>
                   </Button>
                 </ModalFooter>

--- a/src/layout/DefaultLayout.tsx
+++ b/src/layout/DefaultLayout.tsx
@@ -34,15 +34,18 @@ const DefaultLayout = ({
             borderBottom='1px solid'
             width='340px'
             height='60px'
-            borderColor='#777777'>
+            borderColor='#777777'
+          >
             <Heading
               width={210}
               height={51}
               margin='0 auto'
-              textAlign='center'>
+              textAlign='center'
+            >
               <Box
                 fontFamily='Overpass ,sans-serif'
-                color='black'>
+                color='black'
+              >
                 Schedula
               </Box>
             </Heading>
@@ -53,32 +56,38 @@ const DefaultLayout = ({
             direction='column'
             align='left'
             w={360}
-            marginTop={10}>
+            marginTop={10}
+          >
             <DashboardOptions
               isActive={Active == 'dashboard'}
               title='Dashboard'
               icon={<MdOutlineDashboard />}
+              goTo='teste'
             />
 
             <DashboardOptions
               isActive={Active == 'chamados'}
               title='Chamados'
               icon={<MdOutlineViewAgenda />}
+              goTo='teste'
             />
             <DashboardOptions
               isActive={Active == 'registrarChamados'}
               title='Registrar Chamados'
               icon={<MdOutlineCallToAction />}
+              goTo='teste'
             />
             <DashboardOptions
               isActive={Active == 'gerenciarTiposDeChamado'}
               title='Tipos  de Chamados'
               icon={<FiLayout />}
+              goTo='ListaCategoria'
             />
             <DashboardOptions
               isActive={Active == 'tutoriais'}
               title='Tutoriais'
               icon={<MdMonitor />}
+              goTo='teste'
             />
           </Stack>
         </Box>
@@ -89,5 +98,5 @@ const DefaultLayout = ({
   );
 };
 
-// eslint-disable-next-line import/no-default-export
+// eslint-disable-next-line import/no-default-export -- It's a layout.
 export default DefaultLayout;

--- a/src/pages/ListaCategoria.tsx
+++ b/src/pages/ListaCategoria.tsx
@@ -7,19 +7,12 @@ import {
   Text,
 } from '@chakra-ui/react';
 
+import { Data1 } from '@components/DataType';
 import { listcategory } from '@services/testApi';
 
 import { ItemCategory } from '../components/ItemCategory';
 import { ModalCadCategory } from '../components/ModalCadCategory';
 import DefaultLayout from '../layout/DefaultLayout';
-
-export interface Data1 {
-  id: number;
-  name: string;
-  description: string;
-  active: boolean;
-  updatedAt: Date;
-}
 
 type FormProps = {
   id: number;

--- a/src/pages/ListaCategoria.tsx
+++ b/src/pages/ListaCategoria.tsx
@@ -7,7 +7,7 @@ import {
   Text,
 } from '@chakra-ui/react';
 
-import { Data1 } from '@components/DataType';
+import { DataCategory } from '@components/DataType';
 import { listcategory } from '@services/testApi';
 
 import { ItemCategory } from '../components/ItemCategory';
@@ -21,10 +21,12 @@ type FormProps = {
 };
 
 const ListaCategoria = () => {
-  const [categorias, setCategorias] = useState<Data1[]>([]);
+  const [categorias, setCategorias] = useState<
+    DataCategory[]
+  >([]);
   const [isLoading, setIsLoading] = useState<boolean>(true);
 
-  function AddCategory(categoria: Data1) {
+  function AddCategory(categoria: DataCategory) {
     setCategorias([categoria, ...categorias]);
   }
 
@@ -116,7 +118,7 @@ const ListaCategoria = () => {
             {
               //o map só pode listar se tiver com o active == true, não faz isso agora pq a api não existe.
             }
-            {categorias?.map((categoria: Data1) => {
+            {categorias?.map((categoria: DataCategory) => {
               // categoria.active === true ?
               return (
                 <ItemCategory

--- a/src/pages/teste.tsx
+++ b/src/pages/teste.tsx
@@ -7,16 +7,18 @@ import {
   useDisclosure,
 } from '@chakra-ui/react';
 
-import { Data1 } from '@components/DataType';
+import { DataCategory } from '@components/DataType';
 import { ModalCadType } from '@components/ModalCadType';
 
 import DefaultLayout from '../layout/DefaultLayout';
 
 const Teste = () => {
   const { isOpen, onOpen, onClose } = useDisclosure();
-  const [categorias, setCategorias] = useState<Data1[]>([]);
+  const [categorias, setCategorias] = useState<
+    DataCategory[]
+  >([]);
 
-  function callBack(categoria: Data1) {
+  function callBack(categoria: DataCategory) {
     setCategorias([categoria, ...categorias]);
   }
 
@@ -26,7 +28,6 @@ const Teste = () => {
       <Button onClick={onOpen}>Teste Modal Cad.</Button>
       <ModalCadType
         isOpen={isOpen}
-        onOpen={onOpen}
         onClose={onClose}
         callBack={callBack}
       />
@@ -35,7 +36,7 @@ const Teste = () => {
         {
           //o map só pode listar se tiver com o active == true, não faz isso agora pq a api não existe.
         }
-        {categorias?.map((categoria: Data1) => {
+        {categorias?.map((categoria: DataCategory) => {
           // categoria.active === true ?
           return (
             <>

--- a/src/pages/teste.tsx
+++ b/src/pages/teste.tsx
@@ -1,20 +1,58 @@
-import { ReactNode } from 'react';
-import { Heading } from '@chakra-ui/react';
+import { ReactNode, useState } from 'react';
+import {
+  Box,
+  Button,
+  Heading,
+  Text,
+  useDisclosure,
+} from '@chakra-ui/react';
+
+import { Data1 } from '@components/DataType';
+import { ModalCadType } from '@components/ModalCadType';
 
 import DefaultLayout from '../layout/DefaultLayout';
 
-const teste = () => {
+const Teste = () => {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const [categorias, setCategorias] = useState<Data1[]>([]);
+
+  function callBack(categoria: Data1) {
+    setCategorias([categoria, ...categorias]);
+  }
+
   return (
     <>
       <Heading w='100%'>Página Teste</Heading>
+      <Button onClick={onOpen}>Teste Modal Cad.</Button>
+      <ModalCadType
+        isOpen={isOpen}
+        onOpen={onOpen}
+        onClose={onClose}
+        callBack={callBack}
+      />
+      <Box mt='1em' mb='3em'>
+        <Text>Tipos cadastrados no sitema.</Text>
+        {
+          //o map só pode listar se tiver com o active == true, não faz isso agora pq a api não existe.
+        }
+        {categorias?.map((categoria: Data1) => {
+          // categoria.active === true ?
+          return (
+            <>
+              <Text>{categoria.name}</Text>
+              <Text>{categoria.description}</Text>
+            </>
+          );
+        })}
+      </Box>
     </>
   );
 };
 
-teste.getLayout = (page: ReactNode) => {
+Teste.getLayout = (page: ReactNode) => {
   return (
     <DefaultLayout Active='dashboard'>{page}</DefaultLayout>
   );
 };
 
-export default teste;
+export default Teste;

--- a/src/pages/teste.tsx
+++ b/src/pages/teste.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useState } from 'react';
+import { ReactNode, useEffect, useState } from 'react';
 import {
   Box,
   Button,
@@ -7,8 +7,13 @@ import {
   useDisclosure,
 } from '@chakra-ui/react';
 
-import { DataCategory } from '@components/DataType';
+import {
+  DataCategory,
+  DataProbType,
+} from '@components/DataType';
 import { ModalCadType } from '@components/ModalCadType';
+import { ModalEditType } from '@components/ModalEditType';
+import { listcategory } from '@services/testApi';
 
 import DefaultLayout from '../layout/DefaultLayout';
 
@@ -17,6 +22,29 @@ const Teste = () => {
   const [categorias, setCategorias] = useState<
     DataCategory[]
   >([]);
+
+  useEffect(() => {
+    listcategory
+      .get('/users')
+      .then((res) => {
+        setCategorias(res.data);
+      })
+      .catch();
+  }, []);
+
+  function EditCategory(categoria2: DataProbType) {
+    setCategorias(
+      categorias.map((categoria) =>
+        categoria.id === categoria2.id
+          ? {
+              ...categoria,
+              name: categoria2.name,
+              description: categoria2.description,
+            }
+          : { ...categoria }
+      )
+    );
+  }
 
   return (
     <>
@@ -38,6 +66,15 @@ const Teste = () => {
             <>
               <Text>{categoria.name}</Text>
               <Text>{categoria.description}</Text>
+
+              <Button onClick={onOpen}>Editar</Button>
+              <ModalEditType
+                callBack={EditCategory}
+                categoryId={categoria.id}
+                id={categoria.id}
+                isOpen={isOpen}
+                onClose={onClose}
+              />
             </>
           );
         })}

--- a/src/pages/teste.tsx
+++ b/src/pages/teste.tsx
@@ -1,24 +1,16 @@
 import { ReactNode, useEffect, useState } from 'react';
-import {
-  Box,
-  Button,
-  Heading,
-  Text,
-  useDisclosure,
-} from '@chakra-ui/react';
+import { Box, Heading, Text } from '@chakra-ui/react';
 
 import {
   DataCategory,
   DataProbType,
 } from '@components/DataType';
-import { ModalCadType } from '@components/ModalCadType';
 import { ModalEditType } from '@components/ModalEditType';
 import { listcategory } from '@services/testApi';
 
 import DefaultLayout from '../layout/DefaultLayout';
 
 const Teste = () => {
-  const { isOpen, onOpen, onClose } = useDisclosure();
   const [categorias, setCategorias] = useState<
     DataCategory[]
   >([]);
@@ -49,12 +41,6 @@ const Teste = () => {
   return (
     <>
       <Heading w='100%'>Página Teste</Heading>
-      <Button onClick={onOpen}>Teste Modal Cad.</Button>
-      <ModalCadType
-        isOpen={isOpen}
-        onClose={onClose}
-        categoryId={2}
-      />
       <Box mt='1em' mb='3em'>
         <Text>Tipos cadastrados no sitema.</Text>
         {
@@ -66,14 +52,10 @@ const Teste = () => {
             <>
               <Text>{categoria.name}</Text>
               <Text>{categoria.description}</Text>
-
-              <Button onClick={onOpen}>Editar</Button>
               <ModalEditType
                 callBack={EditCategory}
                 categoryId={categoria.id}
                 id={categoria.id}
-                isOpen={isOpen}
-                onClose={onClose}
               />
             </>
           );

--- a/src/pages/teste.tsx
+++ b/src/pages/teste.tsx
@@ -18,10 +18,6 @@ const Teste = () => {
     DataCategory[]
   >([]);
 
-  function callBack(categoria: DataCategory) {
-    setCategorias([categoria, ...categorias]);
-  }
-
   return (
     <>
       <Heading w='100%'>Página Teste</Heading>
@@ -29,7 +25,7 @@ const Teste = () => {
       <ModalCadType
         isOpen={isOpen}
         onClose={onClose}
-        callBack={callBack}
+        categoryId={2}
       />
       <Box mt='1em' mb='3em'>
         <Text>Tipos cadastrados no sitema.</Text>

--- a/src/pages/teste.tsx
+++ b/src/pages/teste.tsx
@@ -1,16 +1,24 @@
 import { ReactNode, useEffect, useState } from 'react';
-import { Box, Heading, Text } from '@chakra-ui/react';
+import {
+  Box,
+  Button,
+  Heading,
+  Text,
+  useDisclosure,
+} from '@chakra-ui/react';
 
 import {
   DataCategory,
   DataProbType,
 } from '@components/DataType';
+import { ModalCadType } from '@components/ModalCadType';
 import { ModalEditType } from '@components/ModalEditType';
 import { listcategory } from '@services/testApi';
 
 import DefaultLayout from '../layout/DefaultLayout';
 
 const Teste = () => {
+  const { isOpen, onOpen, onClose } = useDisclosure();
   const [categorias, setCategorias] = useState<
     DataCategory[]
   >([]);
@@ -38,9 +46,20 @@ const Teste = () => {
     );
   }
 
+  function AddCategory(categoria: DataCategory) {
+    setCategorias([categoria, ...categorias]);
+  }
+
   return (
     <>
       <Heading w='100%'>Página Teste</Heading>
+      <Button onClick={onOpen}>Cadastrar tipo</Button>
+      <ModalCadType
+        categoryId={1}
+        isOpen={isOpen}
+        onClose={onClose}
+        callBack={AddCategory}
+      />
       <Box mt='1em' mb='3em'>
         <Text>Tipos cadastrados no sitema.</Text>
         {

--- a/src/services/testApi.ts
+++ b/src/services/testApi.ts
@@ -8,4 +8,8 @@ export const listcategory = axios.create({
   baseURL: 'https://jsonplaceholder.typicode.com',
 });
 
+export const typeApi = axios.create({
+  baseURL: 'https://jsonplaceholder.typicode.com',
+});
+
 // export microservices here...


### PR DESCRIPTION
O cadastro de tipo tem um call back opcional para caso ele for usado em um lugar fora da lista de tipos (lista categoria). O modal de edição edita e retorna o valor editado no callback. Também foi adicionado um goTo no botão do layout que troca da página atual para outra página quando clicado.